### PR TITLE
Update MWT2.yaml to add PS iut2-net09 & iut2-net10

### DIFF
--- a/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
+++ b/topology/University of Chicago/MWT2 ATLAS UC/MWT2.yaml
@@ -976,6 +976,44 @@ Resources:
           endpoint: iut2-net8.iu.edu
     VOOwnership:
       ATLAS: 100
+  US-MWT2_IU BW4:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+      Miscellaneous Contact:
+        Primary:
+          ID: 3b1876c30549a51501329cbb9678289fc786ac29
+          Name: Frederick Luehring
+      Resource Report Contact:
+        Primary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+      Security Contact:
+        Primary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+    Description: MWT2 perfSONAR-PS Bandwidth instance at Indiana University (Replaces iut2-net2)
+    FQDN: iut2-net10.iu.edu
+    ID: 1223
+    Services:
+      net.perfSONAR.Bandwidth:
+        Description: PerfSonar Bandwidth monitoring node
+        Details:
+          endpoint: iut2-net10.iu.edu
+    VOOwnership:
+      ATLAS: 100
   US-MWT2_IU LAT:
     Active: true
     ContactLists:
@@ -1129,6 +1167,44 @@ Resources:
         Description: PerfSonar Latency monitoring node
         Details:
           endpoint: iut2-net7.iu.edu
+    VOOwnership:
+      ATLAS: 100
+  US-MWT2_IU LAT4:
+    Active: true
+    ContactLists:
+      Administrative Contact:
+        Primary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+      Miscellaneous Contact:
+        Primary:
+          ID: 3b1876c30549a51501329cbb9678289fc786ac29
+          Name: Frederick Luehring
+      Resource Report Contact:
+        Primary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+      Security Contact:
+        Primary:
+          ID: a418fbc5dd33637bba264c01d84d52dd317f2813
+          Name: Judith Stephen
+        Secondary:
+          ID: 0a22bab3de2d83d723811e3fb1ebca904e924a97
+          Name: Lincoln Bryant
+    Description: MWT2 perfSONAR-PS Latency instance at Indiana University (replaces iut2-net1)
+    FQDN: iut2-net09.iu.edu
+    ID: 1222
+    Services:
+      net.perfSONAR.Latency:
+        Description: PerfSonar Latency monitoring node
+        Details:
+          endpoint: iut2-net09.iu.edu
     VOOwnership:
       ATLAS: 100
   US-MWT2_UC BW:


### PR DESCRIPTION
iut2-net09 will replace iut2-net1 as the main perfSONAR latency server are the IU part of MWT2. iut2-net10 will replace iut2-net9 as the main bandwidth perfSONAR server at the IU part move MWT2.